### PR TITLE
Version 1.3.0

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,2 @@
 [files]
-extend-exclude = ["go.sum", "testdata/*.mod"]
+extend-exclude = ["go.sum", "testdata/*.mod", "depsy_test.go"]

--- a/depsy.go
+++ b/depsy.go
@@ -110,16 +110,27 @@ REPL:
 
 // ////////////////////////////////////////////////////////////////////////////////// //
 
+// PrettyPath strips major version info from the path
+func (d Dependency) PrettyPath() string {
+	majorVersion := getMajorVersion(d.Version)
+
+	if strings.HasSuffix(d.Path, "/v"+majorVersion) {
+		return d.Path[:len(d.Path)-(len(majorVersion)+2)]
+	}
+
+	return d.Path
+}
+
 // String returns string representation of dependency
 func (d Dependency) String() string {
 	switch {
 	case d.Extra == "":
-		return d.Path + ":" + d.Version
+		return d.PrettyPath() + ":" + d.Version
 	case d.Extra[0] == '.' || d.Extra[0] == '/':
-		return d.Path + ":" + d.Version + "→" + d.Extra
+		return d.PrettyPath() + ":" + d.Version + "→" + d.Extra
 	}
 
-	return d.Path + ":" + d.Version + "+" + d.Extra
+	return d.PrettyPath() + ":" + d.Version + "+" + d.Extra
 }
 
 // ////////////////////////////////////////////////////////////////////////////////// //
@@ -152,11 +163,6 @@ func parseDependencyLine(data string) Dependency {
 
 	path := getField(info, 0)
 	version, extra := parseVersion(getField(info, 1))
-	majorVersion := getMajorVersion(version)
-
-	if strings.HasSuffix(path, "/v"+majorVersion) {
-		path = path[:len(path)-(len(majorVersion)+2)]
-	}
 
 	return Dependency{
 		Path:    path,
@@ -190,17 +196,12 @@ func parseReplacementLine(data string) replacement {
 
 	fromVer, fromExtra = parseVersion(fromVer)
 	toVer, toExtra = parseVersion(toVer)
-	majorVersion := getMajorVersion(toVer)
 
 	if toPath[0] == '.' || toPath[0] == '/' {
 		return replacement{
 			From:      Dependency{fromPath, fromVer, fromExtra},
 			LocalPath: toPath,
 		}
-	}
-
-	if strings.HasSuffix(toPath, "/v"+majorVersion) {
-		toPath = toPath[:len(toPath)-(len(majorVersion)+2)]
 	}
 
 	return replacement{

--- a/depsy_test.go
+++ b/depsy_test.go
@@ -29,13 +29,22 @@ var _ = Suite(&DepsySuite{})
 func (s *DepsySuite) TestExtract(c *C) {
 	data, err := os.ReadFile("testdata/test1.mod")
 	c.Assert(err, IsNil)
+
 	deps := Extract(data, false)
 	c.Assert(len(deps), Equals, 20)
+
 	deps = Extract(data, true)
 	c.Assert(len(deps), Equals, 74)
+
 	c.Assert(deps[5], DeepEquals, Dependency{"go.etcd.io/etcd/api/v3", "3.6.0", "./api"})
 	c.Assert(deps[16], DeepEquals, Dependency{"golang.org/x/time", "0.0.0", "20210220033141-f8bda1e9f3ba"})
 	c.Assert(deps[27], DeepEquals, Dependency{"github.com/golang-jwt/jwt", "3.2.2", ""})
+
+	c.Assert(deps[5].PrettyPath(), Equals, "go.etcd.io/etcd/api")
+
+	c.Assert(deps[5].String(), Equals, "go.etcd.io/etcd/api:3.6.0→./api")
+	c.Assert(deps[16].String(), Equals, "golang.org/x/time:0.0.0+20210220033141-f8bda1e9f3ba")
+	c.Assert(deps[27].String(), Equals, "github.com/golang-jwt/jwt:3.2.2")
 
 	data, err = os.ReadFile("go.mod")
 	c.Assert(err, IsNil)

--- a/depsy_test.go
+++ b/depsy_test.go
@@ -8,7 +8,7 @@ package depsy
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/essentialkaos/check"
@@ -27,7 +27,7 @@ var _ = Suite(&DepsySuite{})
 // ////////////////////////////////////////////////////////////////////////////////// //
 
 func (s *DepsySuite) TestExtract(c *C) {
-	data, err := ioutil.ReadFile("testdata/test1.mod")
+	data, err := os.ReadFile("testdata/test1.mod")
 	c.Assert(err, IsNil)
 	deps := Extract(data, false)
 	c.Assert(len(deps), Equals, 20)
@@ -37,7 +37,7 @@ func (s *DepsySuite) TestExtract(c *C) {
 	c.Assert(deps[16], DeepEquals, Dependency{"golang.org/x/time", "0.0.0", "20210220033141-f8bda1e9f3ba"})
 	c.Assert(deps[27], DeepEquals, Dependency{"github.com/golang-jwt/jwt", "3.2.2", ""})
 
-	data, err = ioutil.ReadFile("go.mod")
+	data, err = os.ReadFile("go.mod")
 	c.Assert(err, IsNil)
 	deps = Extract(data, false)
 	c.Assert(len(deps), Equals, 1)
@@ -45,7 +45,7 @@ func (s *DepsySuite) TestExtract(c *C) {
 	c.Assert(len(deps), Equals, 4)
 	c.Assert(deps[0], DeepEquals, Dependency{"github.com/essentialkaos/check", "1.4.0", ""})
 
-	data, err = ioutil.ReadFile("testdata/test2.mod")
+	data, err = os.ReadFile("testdata/test2.mod")
 	c.Assert(err, IsNil)
 	deps = Extract(data, true)
 

--- a/depsy_test.go
+++ b/depsy_test.go
@@ -33,7 +33,8 @@ func (s *DepsySuite) TestExtract(c *C) {
 	c.Assert(len(deps), Equals, 20)
 	deps = Extract(data, true)
 	c.Assert(len(deps), Equals, 74)
-	c.Assert(deps[5], DeepEquals, Dependency{"go.etcd.io/etcd/api", "3.6.0", "alpha.0"})
+	c.Assert(deps[5], DeepEquals, Dependency{"go.etcd.io/etcd/api/v3", "3.6.0", "./api"})
+	c.Assert(deps[16], DeepEquals, Dependency{"golang.org/x/time", "0.0.0", "20210220033141-f8bda1e9f3ba"})
 	c.Assert(deps[27], DeepEquals, Dependency{"github.com/golang-jwt/jwt", "3.2.2", ""})
 
 	data, err = ioutil.ReadFile("go.mod")


### PR DESCRIPTION
#### New Features
- Added method `Dependency.PrettyPath` that returns import path without major version

#### Improvements
- Now, `Dependency.Path` contains the original import path defined in `go.mod` file

#### Bugfixes
- Fixed bug with handling replacements for packages with major version info (e.g. `/v2`, `/v3`…)